### PR TITLE
Expose store.dispatch method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Create your reporting middleware
 // /middleware/myReporter.js
 import reporter from 'redux-reporter';
 
-export default reporter(({ type, payload }, getState) => {
+export default reporter(({ type, payload }, getState, dispatch) => {
 
     try {
         // report to external API

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 const defaultSelect = ({ meta = {} }) => meta.report
 
-const reporter = (handler, select = defaultSelect) => ({ getState }) => (next) => (action) => {
+const reporter = (handler, select = defaultSelect) => ({ getState, dispatch }) => (next) => (action) => {
   const returnValue = next(action)
 
   if (typeof action === 'function') {
@@ -13,7 +13,7 @@ const reporter = (handler, select = defaultSelect) => ({ getState }) => (next) =
     return returnValue
   }
 
-  handler(report, getState)
+  handler(report, getState, dispatch)
 
   return returnValue
 }
@@ -33,13 +33,13 @@ const errorSelect = ({ error = false, payload, type }) => {
 
 export const errorReporter = (handler) => reporter(handler, errorSelect)
 
-export const crashReporter = (handler) => ({ getState }) => (next) => (action) => {
+export const crashReporter = (handler) => ({ getState, dispatch }) => (next) => (action) => {
   let returnValue
 
   try {
     returnValue = next(action)
   } catch (err) {
-    handler(err, getState)
+    handler(err, getState, dispatch)
     console.error(err)
   }
 


### PR DESCRIPTION
Some reporters return data that have to be stored in state. For that the `store.dispatch` is necessary.
For example Tune Measurements API require you first to fire an impression action which will return `tracking_id` that has to be used with following actions.